### PR TITLE
Add fluid clear controls and document implementation status

### DIFF
--- a/docs/ImplementationStatus.md
+++ b/docs/ImplementationStatus.md
@@ -1,0 +1,48 @@
+# AURORA Fluid Studio — Implementation Status & Completion Proposal
+
+## 1. Snapshot (April 2024)
+
+| Area | Documentation Promise | Current Implementation | Gap |
+| --- | --- | --- | --- |
+| Core Simulation | WebGPU-first stable fluids with plug-in solvers (Eulerian 2D, PBF 3D, optional Eulerian 3D). | CPU-based Eulerian 2D semi-Lagrangian solver (`EulerianFluid2D`) with curl/pressure controls; single dye buffer; no GPU compute. | Missing multi-solver architecture, particle/3D solvers, GPU acceleration, collision mask integration, undo/erase painting. |
+| Rendering | Full-screen quad with gradient/emitter/distortion modes, post FX hooks. | WGSL fragment shader supporting gradient/emitter/distortion & bloom mix; WebGPU pipeline with Canvas2D fallback. | No background compositing, post-processing stack, gradient editor UI, surface/perspective controls. |
+| Editor UX | Tweakpane panels for global, sim, emitters, painting, rendering, audio, FX, presets. | Single Tweakpane instance with Simulation, Emitter, Rendering, Audio, Actions, Presets folders; minimal controls and default preset list. | Needs global playback/resolution toggles, multi-emitter management, painting tools, FX/post controls, preset import/export, quality presets. |
+| Audio Reactivity | FFT routing matrix with gain normalization, limiter, band smoothing. | Microphone activation, smoothing/gain controls, single-band drive for primary emitter. | No routing matrix UI, normalization/limiter, per-emitter bindings, alternative sources. |
+| Presets | JSON schema with multiple curated presets, import/export. | `defaultPreset` only; load-only workflow. | Need preset authoring UX, serialization, built-in set. |
+| Tooling & Docs | Comprehensive docs suite + QA/perf plans. | Docs populated (Spec, Plan, Editor, Audio, Perf, Presets, Contrib). | Require implementation-focused checklists, progress tracking (this doc), automation for perf tests. |
+
+## 2. Proposed Completion Roadmap
+
+1. **Simulation Parity Foundations**
+   - Modularize solver interface to prepare for future GPU/3D solvers.
+   - Implement dye/velocity clear operations, pause/resume, and emitter brushing refinements (erase, force falloff).
+   - Introduce collision mask data path (even if static textures at first) to unblock painting roadmap.
+
+2. **Rendering Enhancements**
+   - Add gradient editor UI (stop CRUD) backed by ParamStore; expose exposure/bloom in shader uniforms (done) and extend to background compositing hook.
+   - Wire post-processing placeholder API so bloom/chroma/vignette modules can plug in later without breaking changes.
+
+3. **Editor Expansion**
+   - Create Global panel (playback, reset options, resolution scale) and reorganize existing folders.
+   - Add dedicated actions for Clear Dye / Clear Velocity, and surface curl strength + dissipation sliders promised in spec.
+   - Scaffold preset import/export (JSON download/upload) and prepare multi-preset registry.
+
+4. **Audio System Upgrades**
+   - Fix analyser buffer typing, persist smoothing/gain to ParamStore, and expose active-state toggle.
+   - Plan routing matrix schema; introduce simple band-to-strength mapping UI as interim step.
+
+5. **Presets & Docs**
+   - Ship at least three additional curated presets aligned with rendering/audio features.
+   - Maintain this status document alongside changelog; document testing/perf expectations.
+
+## 3. Immediate Sprint (This PR)
+
+- Deliver quick wins toward parity: clear dye/velocity controls, curl strength UI, audio store fixes, analyser type cleanup.
+- Update ParamStore APIs and events to support richer editor interactions.
+- Document status & roadmap (this file) for ongoing tracking.
+
+## 4. Follow-up Recommendations
+
+- Establish automated lint/test gating in CI once lint passes reliably.
+- Profile CPU solver and decide cut-over to WebGPU compute or WASM for higher resolutions.
+- Iterate on UI/UX polish with design mocks referencing Wallpaper Engine baseline.

--- a/src/audio/AudioAnalyser.ts
+++ b/src/audio/AudioAnalyser.ts
@@ -1,7 +1,7 @@
 export class AudioAnalyser {
   private context: AudioContext | null = null;
   private analyser: AnalyserNode | null = null;
-  private dataArray: Float32Array<ArrayBuffer> | null = null;
+  private dataArray: Float32Array | null = null;
   private smoothing = 0.6;
   private gain = 1.0;
   private active = false;
@@ -19,7 +19,7 @@ export class AudioAnalyser {
 
     this.context = context;
     this.analyser = analyser;
-    this.dataArray = new Float32Array(analyser.frequencyBinCount) as Float32Array<ArrayBuffer>;
+    this.dataArray = new Float32Array(analyser.frequencyBinCount);
     this.active = true;
     this.notifyActivation(true);
   }
@@ -46,7 +46,7 @@ export class AudioAnalyser {
 
   getBandValue(index: number): number {
     if (!this.analyser || !this.dataArray) return 0;
-    const buffer = this.dataArray as Float32Array<ArrayBuffer>;
+    const buffer = this.dataArray;
     this.analyser.getFloatFrequencyData(buffer);
     const clampedIndex = Math.min(Math.max(index, 0), buffer.length - 1);
     const db = buffer[clampedIndex];

--- a/src/core/App.ts
+++ b/src/core/App.ts
@@ -49,6 +49,14 @@ export class App {
       this.fluid.reset();
     });
 
+    this.events.on('simulation:clearDye', () => {
+      this.fluid.clearDye();
+    });
+
+    this.events.on('simulation:clearVelocity', () => {
+      this.fluid.clearVelocity();
+    });
+
     this.events.on('presets:apply', (preset) => {
       this.paramStore.applyPreset(preset);
       this.fluid.updateConfig(this.paramStore.state.simulation);

--- a/src/core/ParamStore.ts
+++ b/src/core/ParamStore.ts
@@ -110,15 +110,20 @@ export class ParamStore {
     this.notify();
   }
 
-  setAudioActive(active: boolean) {
+  updateAudio(partial: Partial<AudioParameters>) {
     this._state = {
       ...this._state,
       audio: {
         ...this._state.audio,
-        active
+        ...partial
       }
     };
     this.notify();
+  }
+
+  setAudioActive(active: boolean) {
+    if (this._state.audio.active === active) return;
+    this.updateAudio({ active });
   }
 
   private notify() {

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -3,6 +3,8 @@ import type { Preset } from '../presets/types';
 
 export type AppEventMap = {
   'simulation:reset': void;
+  'simulation:clearDye': void;
+  'simulation:clearVelocity': void;
   'presets:apply': Preset;
   'render:mode': RenderingParameters['mode'];
 };

--- a/src/simulation/EulerianFluid2D.ts
+++ b/src/simulation/EulerianFluid2D.ts
@@ -43,13 +43,21 @@ export class EulerianFluid2D {
   }
 
   reset() {
+    this.clearVelocity();
+    this.clearDye();
+    this.curl.fill(0);
+  }
+
+  clearDye() {
+    this.density.fill(0);
+    this.densityPrev.fill(0);
+  }
+
+  clearVelocity() {
     this.velocityX.fill(0);
     this.velocityY.fill(0);
     this.velocityXPrev.fill(0);
     this.velocityYPrev.fill(0);
-    this.density.fill(0);
-    this.densityPrev.fill(0);
-    this.curl.fill(0);
   }
 
   step(dt: number) {

--- a/src/ui/EditorPanel.ts
+++ b/src/ui/EditorPanel.ts
@@ -45,6 +45,9 @@ export class EditorPanel {
     simFolder
       .addInput(simState, 'pressureIterations', { min: 5, max: 60, step: 1 })
       .on('change', (ev: TpChangeEvent<number>) => this.store.updateSimulation({ pressureIterations: ev.value }));
+    simFolder
+      .addInput(simState, 'curlStrength', { min: 0, max: 50, step: 1 })
+      .on('change', (ev: TpChangeEvent<number>) => this.store.updateSimulation({ curlStrength: ev.value }));
 
     const emitFolder = pane.addFolder({ title: 'Emitter' });
     const emitter = this.store.state.emitters.primary;
@@ -89,18 +92,22 @@ export class EditorPanel {
     audioFolder
       .addInput(audio, 'smoothing', { min: 0, max: 0.9, step: 0.05 })
       .on('change', (ev: TpChangeEvent<number>) => {
-        this.store.setAudioActive(true);
+        this.store.updateAudio({ smoothing: ev.value, active: true });
         this.analyser.setSmoothing(ev.value);
       });
     audioFolder
       .addInput(audio, 'gain', { min: 0.1, max: 4, step: 0.1 })
       .on('change', (ev: TpChangeEvent<number>) => {
-        this.store.setAudioActive(true);
+        this.store.updateAudio({ gain: ev.value, active: true });
         this.analyser.setGain(ev.value);
       });
 
     const actionsFolder = pane.addFolder({ title: 'Actions' });
-    actionsFolder.addButton({ title: 'Clear Simulation' }).on('click', () => this.events.emit('simulation:reset', undefined));
+    actionsFolder.addButton({ title: 'Clear Dye' }).on('click', () => this.events.emit('simulation:clearDye', undefined));
+    actionsFolder
+      .addButton({ title: 'Clear Velocity' })
+      .on('click', () => this.events.emit('simulation:clearVelocity', undefined));
+    actionsFolder.addButton({ title: 'Reset Simulation' }).on('click', () => this.events.emit('simulation:reset', undefined));
 
     const presetsFolder = pane.addFolder({ title: 'Presets' });
     presetsFolder


### PR DESCRIPTION
## Summary
- capture current implementation status versus the documentation and propose a completion roadmap
- expose curl strength plus dedicated clear dye/velocity actions in the editor and fluid solver
- persist audio parameter changes and clean up analyser typing for future audio work

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e32594e52083278195983dc93c4140